### PR TITLE
Remove non-Library Manager libraries from `depends`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Sensors
 url=https://github.com/JVKran/Forced-BME280
 architectures=*
 includes=forcedClimate.h
-depends=stdint, Wire, TinyWireM
+depends=TinyWireM


### PR DESCRIPTION
The `depends` field of [the `library.properties` metadata file](https://arduino.github.io/arduino-cli/dev/library-specification/#library-metadata) can be used to provide a list of library dependencies that should be installed in addition during a Library Manager installation. That is the only purpose it serves. It should not contain anything other than names of libraries that are present in the Library Manager index.

Previously, this library's `depends` field contained elements that were not Library Manager libraries. This had the following effect on installation of the library:

- [Classic Arduino IDE](https://github.com/arduino/Arduino): the library is installed and the invalid elements ignored
- Arduino IDE 2.x: installation of the library fails silently (https://github.com/arduino/arduino-ide/issues/621)
- [Arduino CLI](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib_install/): installation of the library fails with "`Error installing Forced-BME280: No valid dependencies solution found: dependency 'stdint' is not available`"